### PR TITLE
Refactor Ruby script for latest AWS SDK

### DIFF
--- a/get_elb_nodes.rb
+++ b/get_elb_nodes.rb
@@ -1,88 +1,100 @@
-#!/usr/bin/ruby
-require 'aws-sdk'
-require 'trollop'
+#!/usr/bin/env ruby
+
+require 'aws-sdk-ec2'
+require 'aws-sdk-elasticloadbalancing'
 require 'json'
-require File.expand_path(File.dirname(__FILE__) + '/config/config.aws.rb')
+require 'trollop'
 
-begin
-  def fetch_instances_w_config(config_file, opts)
-    elb = AWS::ELB.new
-    ec2 = AWS::EC2.new
-    JSON.parse(File.read(config_file))['groups'].each do |item|
-      elb_group = item['elbName']
-      ssh_user = item['username']
-      ssh_key  = item['sshKey']
-      prefix   = item['groupName']
-      c = 0
-      instance_ids = elb.load_balancers[elb_group].instances.collect(&:id)
-      instance_ids.each do |id|
-        i = ec2.instances[id]
-        tags = i.tags
-        name = tags[:Name]
-        c = c +1
-        if !opts[:runcommand]
-          puts "Host #{prefix}#{c}\n"
-          puts "  Hostname #{i.private_ip_address}\n"
-          puts "  IdentityFile \"#{ssh_key}\"\n"
-          puts "  User #{ssh_user}\n\n"
-        end
-        if opts[:runcommand]
-          sshcmd = "ssh -i #{ssh_key} #{i.private_ip_address} \"#{opts[:runcommand]}\""
-          puts "Executing Command:#{sshcmd}\n"
-          system "#{sshcmd}"
-        end
-      end
-    end
-  end
+def fetch_instances_w_config(config_file, opts)
+  elb = Aws::ElasticLoadBalancing::Client.new
+  ec2 = Aws::EC2::Client.new
+  groups = JSON.parse(File.read(config_file))['groups']
 
-  def fetch_instances_wo_config(opts)
-    elb_group = opts[:name]
-    elb = AWS::ELB.new
-    ec2 = AWS::EC2.new
-    c = 0
-    instance_ids = elb.load_balancers[elb_group].instances.collect(&:id)
+  groups.each do |group|
+    elb_group = group['elbName']
+    ssh_user = group['username']
+    ssh_key = group['sshKey']
+    prefix = group['groupName']
+    count = 0
+
+    instance_ids = elb.describe_load_balancers(load_balancer_names: [elb_group])
+                     .load_balancer_descriptions[0].instances.map(&:instance_id)
+
     instance_ids.each do |id|
-      i = ec2.instances[id]
-      tags = i.tags
-      name = tags[:Name]
-      if opts[:ssh] == false
-        puts "#{i.id} #{name} #{i.private_ip_address}"
-      end
-      if opts[:ssh]
-	c = c +1
-	ssh_user = opts[:user]
-	ssh_key  = opts[:key]
-        prefix   = opts[:prefix]
-	if prefix != ""
-	  puts "Host #{prefix}#{c}\n"
-	else
-	  puts "Host #{name}\n"
-        end
-   	puts "  Hostname #{i.private_ip_address}\n"
+      instance = ec2.describe_instances(instance_ids: [id]).reservations[0].instances[0]
+      tags = instance.tags
+      name = tags.find { |t| t.key == 'Name' }&.value
+      count += 1
+
+      if !opts[:runcommand]
+        puts "Host #{prefix}#{count}\n"
+        puts "  Hostname #{instance.private_ip_address}\n"
         puts "  IdentityFile \"#{ssh_key}\"\n"
-	puts "  User #{ssh_user}\n\n"
+        puts "  User #{ssh_user}\n\n"
+      end
+
+      if opts[:runcommand]
+        sshcmd = "ssh -i #{ssh_key} #{instance.private_ip_address} \"#{opts[:runcommand]}\""
+        puts "Executing Command: #{sshcmd}\n"
+        system sshcmd
       end
     end
   end
+end
 
-## Get CLI options
-  def parse_options
-    opts = Trollop::options do
-      opt :config, "Config File", :type => :string
-      opt :name, "ELB Name", :type => :string
-      opt :ssh, "Output SSH config"
-      opt :user, "SSH User", :type => :string
-      opt :key, "SSH Key File", :type => :string
-      opt :prefix, "Prefix for each instance ex. web results in web1, web2, etc", :type => :string
-      opt :runcommand, "Run command via ssh to each node", :type => :string
+def fetch_instances_wo_config(opts)
+  elb_group = opts[:name]
+  ec2 = Aws::EC2::Client.new
+  elb = Aws::ElasticLoadBalancing::Client.new
+  count = 0
+
+  instance_ids = elb.describe_load_balancers(load_balancer_names: [elb_group])
+                   .load_balancer_descriptions[0].instances.map(&:instance_id)
+
+  instance_ids.each do |id|
+    instance = ec2.describe_instances(instance_ids: [id]).reservations[0].instances[0]
+    tags = instance.tags
+    name = tags.find { |t| t.key == 'Name' }&.value
+
+    if opts[:ssh] == false
+      puts "#{instance.id} #{name} #{instance.private_ip_address}"
     end
-    return opts
+
+    if opts[:ssh]
+      count += 1
+      ssh_user = opts[:user]
+      ssh_key = opts[:key]
+      prefix = opts[:prefix]
+
+      if prefix != ""
+        puts "Host #{prefix}#{count}\n"
+      else
+        puts "Host #{name}\n"
+      end
+
+      puts "  Hostname #{instance.private_ip_address}\n"
+      puts "  IdentityFile \"#{ssh_key}\"\n"
+      puts "  User #{ssh_user}\n\n"
+    end
+  end
+end
+
+def parse_options
+  Trollop::options do
+    opt :config, "Config File", type: :string
+    opt :name, "ELB Name", type: :string
+    opt :ssh, "Output SSH config"
+    opt :user, "SSH User", type: :string
+    opt :key, "SSH Key File", type: :string
+    opt :prefix, "Prefix for each instance ex. web results in web1, web2, etc", type: :string
+    opt :runcommand, "Run command via ssh to each node", type: :string
   end
 end
 
 opts = parse_options
+
 if opts[:config]
-  fetch_instances_w_config opts[:config], opts
+  fetch_instances_w_config(opts[:config], opts)
 else
-  fetch_instances_wo_config opts 
+  fetch_instances_wo_config(opts)
 end


### PR DESCRIPTION
I used this script about ten years ago and forked it. Had a reason to use it again recently. 

I changed:
* Updated require statements to use the new AWS SDK version (aws-sdk-ec2 and aws-sdk-elasticloadbalancing).
* Changed the way the instance_ids are retrieved to use the describe_load_balancers method from the Elastic Load Balancing API.
* Changed the way the instance name is retrieved to use the find method on the tags array.
* Moved the parse_options method outside of the begin block.
* I formatted the code to follow Ruby's best practices.